### PR TITLE
Test: Add unit tests for Service layer and Controller validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 *.ipr
 *.iws
 out/
+.vscode/
 
 # Build artifacts
 *.class

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     
     // .env 파일 자동 로드

--- a/app/src/test/java/party/manitto/domain/match/MatchServiceTest.kt
+++ b/app/src/test/java/party/manitto/domain/match/MatchServiceTest.kt
@@ -1,0 +1,71 @@
+package party.manitto.domain.match
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import party.manitto.domain.participant.ParticipantRepository
+import party.manitto.global.CustomException
+import party.manitto.global.ErrorCode
+import party.manitto.global.entity.Participant
+import party.manitto.global.entity.Party
+import party.manitto.global.entity.User
+
+@ExtendWith(MockKExtension::class)
+class MatchServiceTest {
+
+    @MockK
+    lateinit var participantRepository: ParticipantRepository
+
+    @MockK
+    lateinit var matchedResultRepository: MatchedResultRepository
+
+    @MockK
+    lateinit var mailService: MailService
+
+    @InjectMockKs
+    lateinit var matchService: MatchService
+
+    @Test
+    fun `matchAndSave - 참가자가 2명 미만이면 예외 발생`() {
+        // given
+        val partyId = 1L
+        val party = Party(id = partyId, name = "Test Party", inviteCode = "CODE", host = null)
+        val participant1 = Participant(id = 1L, party = party, user = null, guestName = "A", guestEmail = "a@a.com")
+        
+        every { participantRepository.findByPartyId(partyId) } returns listOf(participant1)
+
+        // when & then
+        val exception = assertThrows<CustomException> {
+            matchService.matchAndSave(partyId)
+        }
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.errorCode)
+    }
+
+    @Test
+    fun `matchAndSave - 정상적으로 매칭하고 이메일을 저장한다`() {
+        // given
+        val partyId = 1L
+        val party = Party(id = partyId, name = "Test Party", inviteCode = "CODE", host = null)
+        val p1 = Participant(id = 1L, party = party, user = null, guestName = "A", guestEmail = "a@a.com")
+        val p2 = Participant(id = 2L, party = party, user = null, guestName = "B", guestEmail = "b@b.com")
+        
+        every { participantRepository.findByPartyId(partyId) } returns listOf(p1, p2)
+        every { matchedResultRepository.saveAll(any<List<party.manitto.global.entity.MatchedResult>>()) } returns emptyList()
+        every { mailService.sendMatchEmailAsync(any(), any(), any()) } returns Unit
+
+        // when
+        val response = matchService.matchAndSave(partyId)
+
+        // then
+        assertEquals("매칭 완료 및 이메일 발송 중입니다.", response.message)
+        verify(exactly = 1) { matchedResultRepository.saveAll(any<List<party.manitto.global.entity.MatchedResult>>()) }
+        // 2명에게 이메일 발송
+        verify(exactly = 2) { mailService.sendMatchEmailAsync(any(), any(), any()) }
+    }
+}

--- a/app/src/test/java/party/manitto/domain/party/PartyControllerValidationTest.kt
+++ b/app/src/test/java/party/manitto/domain/party/PartyControllerValidationTest.kt
@@ -1,0 +1,58 @@
+package party.manitto.domain.party
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import party.manitto.config.SecurityConfig
+import party.manitto.domain.party.dto.CreatePartyRequest
+import party.manitto.domain.user.JwtService
+import party.manitto.global.GlobalExceptionHandler
+
+@WebMvcTest(
+    controllers = [PartyController::class],
+    excludeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [SecurityConfig::class])]
+)
+class PartyControllerValidationTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @MockkBean
+    lateinit var partyService: PartyService
+    
+    // SecurityConfig를 제외했으므로 JwtService 등의 bean 의존성 문제 해결을 위해 Mock 필요할 수 있음
+    // WebMvcTest는 SecurityConfig를 로드하려고 시도할 수 있으므로, 
+    // 실제로는 excludeFilters로 SecurityConfig 제외하고, WithMockUser로 우회하는 전략 사용
+    @MockkBean
+    lateinit var jwtService: JwtService
+
+    @MockkBean
+    lateinit var userRepository: party.manitto.domain.user.UserRepository
+
+    @Test
+    @WithMockUser
+    fun `createParty - 이름이 비어있으면 400 응답`() {
+        val request = CreatePartyRequest(name = "") // Invalid
+
+        mockMvc.post("/api/parties") {
+            with(csrf())
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(request)
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.error") { value("BAD_REQUEST") }
+        }
+    }
+}

--- a/app/src/test/java/party/manitto/domain/party/PartyServiceTest.kt
+++ b/app/src/test/java/party/manitto/domain/party/PartyServiceTest.kt
@@ -48,7 +48,13 @@ class PartyServiceTest {
         // then
         assertNotNull(response)
         assertEquals("My Party", response.name)
-        verify { partyRepository.save(any()) }
+        
+        // 검증 로직 강화: 저장되는 Party 객체의 속성이 요청값과 일치하는지 확인
+        verify { 
+            partyRepository.save(match { 
+                it.name == "My Party" && it.host == user 
+            }) 
+        }
     }
 
     @Test

--- a/app/src/test/java/party/manitto/domain/party/PartyServiceTest.kt
+++ b/app/src/test/java/party/manitto/domain/party/PartyServiceTest.kt
@@ -1,0 +1,77 @@
+package party.manitto.domain.party
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import party.manitto.domain.match.MatchedResultRepository
+import party.manitto.domain.participant.ParticipantRepository
+import party.manitto.global.CustomException
+import party.manitto.global.ErrorCode
+import party.manitto.global.entity.Party
+import party.manitto.global.entity.User
+import java.util.*
+
+@ExtendWith(MockKExtension::class)
+class PartyServiceTest {
+
+    @MockK
+    lateinit var partyRepository: PartyRepository
+
+    @MockK
+    lateinit var matchedResultRepository: MatchedResultRepository
+
+    @MockK
+    lateinit var participantRepository: ParticipantRepository
+
+    @InjectMockKs
+    lateinit var partyService: PartyService
+
+    @Test
+    fun `createParty - 성공적으로 파티를 생성한다`() {
+        // given
+        val user = User(id = 1L, email = "test@test.com", name = "tester")
+        val party = Party(id = 1L, name = "My Party", inviteCode = "ABCDEF", host = user)
+
+        every { partyRepository.existsByInviteCode(any()) } returns false
+        every { partyRepository.save(any()) } returns party
+
+        // when
+        val response = partyService.createParty("My Party", user)
+
+        // then
+        assertNotNull(response)
+        assertEquals("My Party", response.name)
+        verify { partyRepository.save(any()) }
+    }
+
+    @Test
+    fun `getPartyById - 존재하지 않는 파티 조회 시 예외 발생`() {
+        // given
+        every { partyRepository.findById(999L) } returns Optional.empty()
+
+        // when & then
+        val exception = assertThrows<CustomException> {
+            partyService.getPartyById(999L)
+        }
+        assertEquals(ErrorCode.PARTY_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    fun `getPartyByInviteCode - 유효하지 않은 코드로 조회 시 예외 발생`() {
+        // given
+        every { partyRepository.findByInviteCode("INVALID") } returns null
+
+        // when & then
+        val exception = assertThrows<CustomException> {
+            partyService.getPartyByInviteCode("INVALID")
+        }
+        assertEquals(ErrorCode.INVALID_INVITE_CODE, exception.errorCode)
+    }
+}


### PR DESCRIPTION
## 테스트 코드 추가

### 변경 사항
1. **테스트 환경 설정**
   - `MockK`, `SpringMockK` 의존성 추가 (Kotlin Idiomatic mocking)
   - `spring-security-test` 추가

2. **단위 테스트 작성**
   - **PartyService**: 파티 생성 및 조회 성공/실패 케이스 검증
   - **MatchService**: 매칭 로직 및 이메일 발송 호출(Mock) 검증
   - **PartyController**: `@Valid` 어노테이션 기반 입력값 유효성 검사 테스트 (400 Bad Request)

### 검증 결과
- `./gradlew :app:test` 통과 확인