### PR TITLE
Feat: 파티 참가 인원 30명 제한(30명) 및 동시성 가드

### DIFF
--- a/app/src/main/java/party/manitto/domain/participant/ParticipantRepository.kt
+++ b/app/src/main/java/party/manitto/domain/participant/ParticipantRepository.kt
@@ -25,4 +25,6 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         @Param("partyId") partyId: Long,
         @Param("email") email: String
     ): Participant?
+
+    fun countByPartyId(partyId: Long): Long
 }

--- a/app/src/main/java/party/manitto/domain/participant/ParticipantService.kt
+++ b/app/src/main/java/party/manitto/domain/participant/ParticipantService.kt
@@ -5,6 +5,8 @@ import org.springframework.transaction.annotation.Transactional
 import party.manitto.domain.match.MatchedResultRepository
 import party.manitto.domain.participant.dto.ParticipantResponse
 import party.manitto.domain.party.PartyRepository
+import party.manitto.global.CustomException
+import party.manitto.global.ErrorCode
 import party.manitto.global.entity.Participant
 import party.manitto.global.entity.Party
 import party.manitto.global.entity.User
@@ -17,27 +19,32 @@ class ParticipantService(
 ) {
     @Transactional
     fun joinPartyById(partyId: Long, user: User, nickname: String? = null): ParticipantResponse {
-        val party = partyRepository.findById(partyId)
-            .orElseThrow { IllegalArgumentException("파티가 존재하지 않습니다.") }
+        val party = partyRepository.findByIdForUpdate(partyId)
+            ?: throw CustomException(ErrorCode.PARTY_NOT_FOUND)
         return joinParty(party, user, nickname)
     }
 
     @Transactional
     fun joinPartyByInviteCode(inviteCode: String, user: User, nickname: String? = null): ParticipantResponse {
-        val party = partyRepository.findByInviteCode(inviteCode)
-            ?: throw IllegalArgumentException("유효하지 않은 초대 코드입니다.")
+        val party = partyRepository.findByInviteCodeForUpdate(inviteCode)
+            ?: throw CustomException(ErrorCode.INVALID_INVITE_CODE)
         return joinParty(party, user, nickname)
     }
 
     private fun joinParty(party: Party, user: User, nickname: String?): ParticipantResponse {
         // 이미 매칭된 파티에는 참가 불가
         if (matchedResultRepository.existsByParty(party)) {
-            throw IllegalArgumentException("이미 매칭이 완료된 파티에는 참가할 수 없습니다.")
+            throw CustomException(ErrorCode.ALREADY_MATCHED)
+        }
+
+        val currentCount = participantRepository.countByPartyId(party.id)
+        if (currentCount >= Party.MAX_PARTICIPANTS) {
+            throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
         }
 
         val existing = participantRepository.findByPartyIdAndUser(party.id, user)
         if (existing != null) {
-            throw IllegalArgumentException("이미 이 파티에 참가한 사용자입니다.")
+            throw CustomException(ErrorCode.ALREADY_JOINED_PARTY)
         }
 
         val participant = participantRepository.save(
@@ -58,8 +65,8 @@ class ParticipantService(
 
     @Transactional
     fun joinPartyAsGuest(partyId: Long, name: String, email: String): ParticipantResponse {
-        val party = partyRepository.findById(partyId)
-            .orElseThrow { IllegalArgumentException("파티가 존재하지 않습니다.") }
+        val party = partyRepository.findByIdForUpdate(partyId)
+            ?: throw CustomException(ErrorCode.PARTY_NOT_FOUND)
         return joinPartyAsGuest(party, name, email)
     }
 
@@ -69,21 +76,26 @@ class ParticipantService(
         name: String,
         email: String
     ): ParticipantResponse {
-        val party = partyRepository.findByInviteCode(inviteCode)
-            ?: throw IllegalArgumentException("유효하지 않은 초대 코드입니다.")
+        val party = partyRepository.findByInviteCodeForUpdate(inviteCode)
+            ?: throw CustomException(ErrorCode.INVALID_INVITE_CODE)
         return joinPartyAsGuest(party, name, email)
     }
 
     private fun joinPartyAsGuest(party: Party, name: String, email: String): ParticipantResponse {
         // 이미 매칭된 파티에는 참가 불가
         if (matchedResultRepository.existsByParty(party)) {
-            throw IllegalArgumentException("이미 매칭이 완료된 파티에는 참가할 수 없습니다.")
+            throw CustomException(ErrorCode.ALREADY_MATCHED)
+        }
+
+        val currentCount = participantRepository.countByPartyId(party.id)
+        if (currentCount >= Party.MAX_PARTICIPANTS) {
+            throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
         }
 
         // 같은 이메일로 이미 참가했는지 확인
         val existing = participantRepository.findByPartyIdAndGuestEmail(party.id, email)
         if (existing != null) {
-            throw IllegalArgumentException("이미 이 파티에 참가한 이메일입니다.")
+            throw CustomException(ErrorCode.ALREADY_JOINED_EMAIL)
         }
 
         val participant = participantRepository.save(
@@ -100,15 +112,15 @@ class ParticipantService(
     @Transactional
     fun deleteParticipant(partyId: Long, participantId: Long) {
         val participant = participantRepository.findById(participantId)
-            .orElseThrow { IllegalArgumentException("참가자를 찾을 수 없습니다.") }
+            .orElseThrow { CustomException(ErrorCode.PARTICIPANT_NOT_FOUND) }
 
         if (participant.party.id != partyId) {
-            throw IllegalArgumentException("파티 정보가 일치하지 않습니다.")
+            throw CustomException(ErrorCode.PARTICIPANT_PARTY_MISMATCH)
         }
 
         // 매칭 완료된 파티에서는 삭제 불가
         if (matchedResultRepository.existsByParty(participant.party)) {
-            throw IllegalArgumentException("이미 매칭이 완료된 파티에서는 참가자를 삭제할 수 없습니다.")
+            throw CustomException(ErrorCode.ALREADY_MATCHED)
         }
 
         participantRepository.delete(participant)

--- a/app/src/main/java/party/manitto/domain/participant/ParticipantService.kt
+++ b/app/src/main/java/party/manitto/domain/participant/ParticipantService.kt
@@ -17,6 +17,17 @@ class ParticipantService(
     private val partyRepository: PartyRepository,
     private val matchedResultRepository: MatchedResultRepository
 ) {
+    private fun validatePartyIsJoinable(party: Party) {
+        if (matchedResultRepository.existsByParty(party)) {
+            throw CustomException(ErrorCode.ALREADY_MATCHED)
+        }
+
+        val currentCount = participantRepository.countByPartyId(party.id)
+        if (currentCount >= Party.MAX_PARTICIPANTS) {
+            throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
+        }
+    }
+
     @Transactional
     fun joinPartyById(partyId: Long, user: User, nickname: String? = null): ParticipantResponse {
         val party = partyRepository.findByIdForUpdate(partyId)
@@ -32,15 +43,7 @@ class ParticipantService(
     }
 
     private fun joinParty(party: Party, user: User, nickname: String?): ParticipantResponse {
-        // 이미 매칭된 파티에는 참가 불가
-        if (matchedResultRepository.existsByParty(party)) {
-            throw CustomException(ErrorCode.ALREADY_MATCHED)
-        }
-
-        val currentCount = participantRepository.countByPartyId(party.id)
-        if (currentCount >= Party.MAX_PARTICIPANTS) {
-            throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
-        }
+        validatePartyIsJoinable(party)
 
         val existing = participantRepository.findByPartyIdAndUser(party.id, user)
         if (existing != null) {
@@ -82,15 +85,7 @@ class ParticipantService(
     }
 
     private fun joinPartyAsGuest(party: Party, name: String, email: String): ParticipantResponse {
-        // 이미 매칭된 파티에는 참가 불가
-        if (matchedResultRepository.existsByParty(party)) {
-            throw CustomException(ErrorCode.ALREADY_MATCHED)
-        }
-
-        val currentCount = participantRepository.countByPartyId(party.id)
-        if (currentCount >= Party.MAX_PARTICIPANTS) {
-            throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
-        }
+        validatePartyIsJoinable(party)
 
         // 같은 이메일로 이미 참가했는지 확인
         val existing = participantRepository.findByPartyIdAndGuestEmail(party.id, email)

--- a/app/src/main/java/party/manitto/domain/party/PartyRepository.kt
+++ b/app/src/main/java/party/manitto/domain/party/PartyRepository.kt
@@ -1,11 +1,23 @@
 package party.manitto.domain.party
 
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import party.manitto.global.entity.Party
 import party.manitto.global.entity.User
 
 interface PartyRepository : JpaRepository<Party, Long> {
     fun findByInviteCode(inviteCode: String): Party?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByInviteCodeForUpdate(inviteCode: String): Party?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Party p WHERE p.id = :partyId")
+    fun findByIdForUpdate(@Param("partyId") partyId: Long): Party?
+
     fun existsByInviteCode(inviteCode: String): Boolean
     fun findByHost(host: User): List<Party>
 }

--- a/app/src/main/java/party/manitto/domain/party/PartyService.kt
+++ b/app/src/main/java/party/manitto/domain/party/PartyService.kt
@@ -36,13 +36,15 @@ class PartyService(
         participants: List<GuestParticipantRequest>? = null
     ): PartyResponse {
         val hostEmailLower = hostEmail.lowercase()
-        val uniqueAdditionalCount = participants
+
+        val uniqueAdditionalGuests = participants
             .orEmpty()
-            .map { it.email.lowercase() }
-            .filter { it != hostEmailLower }
-            .distinct()
-            .size
-        if (1 + uniqueAdditionalCount > Party.MAX_PARTICIPANTS) {
+            .asSequence()
+            .filter { it.email.lowercase() != hostEmailLower }
+            .distinctBy { it.email.lowercase() }
+            .toList()
+
+        if (1 + uniqueAdditionalGuests.size > Party.MAX_PARTICIPANTS) {
             throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
         }
 
@@ -61,26 +63,17 @@ class PartyService(
         participantRepository.save(hostParticipant)
         saved.participants.add(hostParticipant)
 
-        // 추가 게스트 참가자들 자동 참여 (이메일 중복 방지)
-        val seenEmails = mutableSetOf(hostEmailLower)
-        participants
-            .orEmpty()
-            .forEach { guest ->
-                val emailLower = guest.email.lowercase()
-                if (emailLower in seenEmails) {
-                    return@forEach
-                }
-                seenEmails.add(emailLower)
-
-                val participant = Participant(
-                    user = null,
-                    party = saved,
-                    guestName = guest.name,
-                    guestEmail = guest.email
-                )
-                participantRepository.save(participant)
-                saved.participants.add(participant)
-            }
+        // 추가 게스트 참가자들 자동 참여 (이메일 중복/호스트 이메일 제외)
+        uniqueAdditionalGuests.forEach { guest ->
+            val participant = Participant(
+                user = null,
+                party = saved,
+                guestName = guest.name,
+                guestEmail = guest.email
+            )
+            participantRepository.save(participant)
+            saved.participants.add(participant)
+        }
 
         // 저장된 파티를 다시 조회하여 participants 컬렉션을 로드
         val partyWithParticipants = partyRepository.findById(saved.id)

--- a/app/src/main/java/party/manitto/domain/party/PartyService.kt
+++ b/app/src/main/java/party/manitto/domain/party/PartyService.kt
@@ -35,6 +35,17 @@ class PartyService(
         hostEmail: String,
         participants: List<GuestParticipantRequest>? = null
     ): PartyResponse {
+        val hostEmailLower = hostEmail.lowercase()
+        val uniqueAdditionalCount = participants
+            .orEmpty()
+            .map { it.email.lowercase() }
+            .filter { it != hostEmailLower }
+            .distinct()
+            .size
+        if (1 + uniqueAdditionalCount > Party.MAX_PARTICIPANTS) {
+            throw CustomException(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED)
+        }
+
         val inviteCode = generateUniqueInviteCode()
         val newParty = Party(name = name, inviteCode = inviteCode, host = null)
         val saved = partyRepository.save(newParty)
@@ -51,7 +62,7 @@ class PartyService(
         saved.participants.add(hostParticipant)
 
         // 추가 게스트 참가자들 자동 참여 (이메일 중복 방지)
-        val seenEmails = mutableSetOf(hostEmail.lowercase())
+        val seenEmails = mutableSetOf(hostEmailLower)
         participants
             .orEmpty()
             .forEach { guest ->

--- a/app/src/main/java/party/manitto/global/ErrorCode.kt
+++ b/app/src/main/java/party/manitto/global/ErrorCode.kt
@@ -17,5 +17,9 @@ enum class ErrorCode(
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티를 찾을 수 없습니다."),
     PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "참가자를 찾을 수 없습니다."),
     INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 초대 코드입니다."),
-    ALREADY_MATCHED(HttpStatus.BAD_REQUEST, "이미 매칭이 완료된 파티입니다.")
+    ALREADY_MATCHED(HttpStatus.BAD_REQUEST, "이미 매칭이 완료된 파티입니다."),
+    PARTY_PARTICIPANT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "파티 참가 인원(30명) 제한을 초과했습니다."),
+    ALREADY_JOINED_PARTY(HttpStatus.BAD_REQUEST, "이미 이 파티에 참가한 사용자입니다."),
+    ALREADY_JOINED_EMAIL(HttpStatus.BAD_REQUEST, "이미 이 파티에 참가한 이메일입니다."),
+    PARTICIPANT_PARTY_MISMATCH(HttpStatus.BAD_REQUEST, "파티 정보가 일치하지 않습니다.")
 }

--- a/app/src/main/java/party/manitto/global/entity/Party.kt
+++ b/app/src/main/java/party/manitto/global/entity/Party.kt
@@ -34,6 +34,8 @@ data class Party(
     val participants: MutableList<Participant> = mutableListOf()
 ) {
     companion object {
+        const val MAX_PARTICIPANTS: Int = 30
+
         // 혼동되는 문자 제외 (0,O,o,1,I,i,l,L)
         private val CHARS = "ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"
         

--- a/app/src/test/java/party/manitto/domain/participant/ParticipantServiceTest.kt
+++ b/app/src/test/java/party/manitto/domain/participant/ParticipantServiceTest.kt
@@ -1,0 +1,71 @@
+package party.manitto.domain.participant
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import party.manitto.domain.match.MatchedResultRepository
+import party.manitto.domain.party.PartyRepository
+import party.manitto.global.CustomException
+import party.manitto.global.ErrorCode
+import party.manitto.global.entity.Party
+import party.manitto.global.entity.User
+
+@ExtendWith(MockKExtension::class)
+class ParticipantServiceTest {
+
+    @MockK
+    lateinit var participantRepository: ParticipantRepository
+
+    @MockK
+    lateinit var partyRepository: PartyRepository
+
+    @MockK
+    lateinit var matchedResultRepository: MatchedResultRepository
+
+    @InjectMockKs
+    lateinit var participantService: ParticipantService
+
+    @Test
+    fun `joinPartyById - 파티 인원 제한(30명) 초과 시 예외 발생`() {
+        // given
+        val partyId = 1L
+        val party = Party(id = partyId, name = "Test Party", inviteCode = "ABCDEF", host = null)
+        val user = User(id = 10L, email = "u@test.com", name = "user")
+
+        every { partyRepository.findByIdForUpdate(partyId) } returns party
+        every { matchedResultRepository.existsByParty(party) } returns false
+        every { participantRepository.countByPartyId(partyId) } returns Party.MAX_PARTICIPANTS.toLong()
+        every { participantRepository.findByPartyIdAndUser(partyId, user) } returns null
+
+        // when & then
+        val exception = assertThrows<CustomException> {
+            participantService.joinPartyById(partyId, user)
+        }
+        assertEquals(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED, exception.errorCode)
+        verify(exactly = 0) { participantRepository.save(any()) }
+    }
+
+    @Test
+    fun `joinPartyAsGuest - 파티 인원 제한(30명) 초과 시 예외 발생`() {
+        // given
+        val partyId = 1L
+        val party = Party(id = partyId, name = "Test Party", inviteCode = "ABCDEF", host = null)
+
+        every { partyRepository.findByIdForUpdate(partyId) } returns party
+        every { matchedResultRepository.existsByParty(party) } returns false
+        every { participantRepository.countByPartyId(partyId) } returns Party.MAX_PARTICIPANTS.toLong()
+
+        // when & then
+        val exception = assertThrows<CustomException> {
+            participantService.joinPartyAsGuest(partyId, name = "Guest", email = "guest@test.com")
+        }
+        assertEquals(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED, exception.errorCode)
+        verify(exactly = 0) { participantRepository.save(any()) }
+    }
+}

--- a/app/src/test/java/party/manitto/domain/party/PartyServiceTest.kt
+++ b/app/src/test/java/party/manitto/domain/party/PartyServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import party.manitto.domain.match.MatchedResultRepository
 import party.manitto.domain.participant.ParticipantRepository
+import party.manitto.domain.party.dto.GuestParticipantRequest
 import party.manitto.global.CustomException
 import party.manitto.global.ErrorCode
 import party.manitto.global.entity.Party
@@ -80,5 +81,29 @@ class PartyServiceTest {
             partyService.getPartyByInviteCode("INVALID")
         }
         assertEquals(ErrorCode.INVALID_INVITE_CODE, exception.errorCode)
+    }
+
+    @Test
+    fun `createGuestParty - 파티 인원 제한(30명) 초과 시 예외 발생`() {
+        // given
+        val hostEmail = "host@test.com"
+        val participants = (1..30).map {
+            GuestParticipantRequest(name = "P$it", email = "p$it@test.com")
+        }
+
+        // when & then
+        val exception = assertThrows<CustomException> {
+            partyService.createGuestParty(
+                name = "Test Party",
+                hostName = "Host",
+                hostEmail = hostEmail,
+                participants = participants
+            )
+        }
+        assertEquals(ErrorCode.PARTY_PARTICIPANT_LIMIT_EXCEEDED, exception.errorCode)
+
+        // 제한 위반이면 DB 작업이 발생하지 않아야 함
+        verify(exactly = 0) { partyRepository.save(any()) }
+        verify(exactly = 0) { participantRepository.save(any()) }
     }
 }


### PR DESCRIPTION
## 변경 배경
파티가 커질수록(대규모/동시 참가) 참가 인원 초과, 중복 참가, 매칭 이후 참가 등 엣지케이스가 늘어나 운영/비용/CS 리스크가 커집니다.
분산처리(outbox/worker) 작업 전에 도메인 가드레일을 먼저 고정해, 이후 성능/정합성 전후 비교가 가능하도록 했습니다.

## 변경 사항
- 파티 최대 참가 인원 30명 제한 도입: `Party.MAX_PARTICIPANTS = 30`
- 참가(로그인/게스트) 시 인원 초과 방지 및 에러코드로 응답
- 게스트 파티 생성 시(호스트 포함) participants 입력으로 30명 초과되면 차단
- 동시 참가 경쟁 상황에서 30명 초과를 줄이기 위해 참가 시 파티 row `PESSIMISTIC_WRITE` 락 적용
- IllegalArgumentException 기반 응답을 `CustomException + ErrorCode`로 정리
- 테스트 추가/보강
  - `ParticipantServiceTest`: 인원 제한 초과 케이스
  - `PartyServiceTest`: 게스트 파티 생성 인원 제한 초과 케이스

## 테스트
- `./gradlew test` 통과